### PR TITLE
fix: TextIOWrapperエラーを修正してファイルパスを正しく処理

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -128,8 +128,7 @@ class VideoMisuseAnalyzer:
 
         for file_path in json_files:
             try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    tweets = safe_json_load(f)
+                tweets = safe_json_load(str(file_path))
 
                 for tweet in tweets:
                     total_tweets += 1


### PR DESCRIPTION
## 概要
- `src/analyzer.py`でTextIOWrapperエラーが発生していた問題を修正
- `safe_json_load`関数にファイルオブジェクトではなくファイルパスを渡すよう変更

## 修正内容
- `safe_json_load(f)` → `safe_json_load(str(file_path))`に変更
- ファイルの開閉処理を`safe_json_load`関数内で行うよう統一

## テスト計画
- [ ] analyzerの基本動作確認
- [ ] JSONファイル読み込み処理の確認
- [ ] エラーログの解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)